### PR TITLE
Increase Linux compatibility cp command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "microbundle watch",
     "post": "mv dist/bundle_new.modern.js dist/bundle_new.js",
     "post:dev": "mv dist/bundle_new.modern.js dist/bundle_new.js & mv dist/bundle_new.modern.js.map dist/bundle_new.js.map",
-    "publish": "rm -rf ../final_build && mkdir ../final_build/ && mkdir ../final_build/src/ && cp -R {manifest.json,dist} ../final_build/ && cp -R src/{assets,popup.html,styles,background.js} ../final_build/src/ && cd .. && zip -r final_build_$npm_package_version.zip final_build",
+    "copy": "cp -R manifest.json ../final_build/ && cp -R dist ../final_build/ && cp -R src/assets ../final_build/src/ && cp -R src/popup.html ../final_build/src/ && cp -R src/styles ../final_build/src/ && cp -R src/background.js ../final_build/src/ && cd .. && zip -r final_build_$npm_package_version.zip final_build",
+    "publish": "rm -rf ../final_build && mkdir ../final_build/ && mkdir ../final_build/src/ && npm run copy",
     "final": "npm run build && npm run publish"
   },
   "author": "Naman Malhotra",


### PR DESCRIPTION
Rewrite the copy instruction removing the braces to increase Linux compatibility `cp` command.

Instead to use `cp -R {manifest.json,dist} ../final_build/`
I slipt to two separate copy instructions.

The best solution probable is to use a lib to realize that copy and to keep cross-platform.